### PR TITLE
Handle monitor unplug

### DIFF
--- a/dwl.c
+++ b/dwl.c
@@ -706,7 +706,8 @@ closemon(Monitor *m, Monitor *newmon)
 	// move all the clients on a closed monitor to another one
 	Client *c;
 
-	focusclient(selclient(), focustop(dirtomon(-1)), 1);
+	selmon = newmon;
+	focusclient(selclient(), focustop(newmon), 1);
 	wl_list_for_each(c, &clients, link) {
 		if (c->isfloating && c->geom.x > m->m.width)
 			resize(c, c->geom.x - m->w.width, c->geom.y,

--- a/dwl.c
+++ b/dwl.c
@@ -2149,8 +2149,8 @@ unmapnotify(struct wl_listener *listener, void *data)
 void
 updatemons()
 {
-	sgeom = *wlr_output_layout_get_box(output_layout, NULL);
 	Monitor *m;
+	sgeom = *wlr_output_layout_get_box(output_layout, NULL);
 	wl_list_for_each(m, &mons, link) {
 		/* Get the effective monitor geometry to use for surfaces */
 		m->m = m->w = *wlr_output_layout_get_box(output_layout, m->wlr_output);

--- a/dwl.c
+++ b/dwl.c
@@ -707,6 +707,7 @@ closemon(Monitor *m)
 	Monitor *newmon;
 	Client *c;
 
+	focusclient(selclient(), focustop(dirtomon(-1)), 1);
 	wl_list_for_each(newmon, &mons, link) {
 		wl_list_for_each(c, &clients, link) {
 			if (c->isfloating && c->geom.x > m->m.width)

--- a/dwl.c
+++ b/dwl.c
@@ -709,10 +709,9 @@ closemon(Monitor *m)
 
 	wl_list_for_each(newmon, &mons, link) {
 		wl_list_for_each(c, &clients, link) {
-			if (c->isfloating && c->geom.x > m->m.width) {
+			if (c->isfloating && c->geom.x > m->m.width)
 				resize(c, c->geom.x - m->w.width, c->geom.y,
-						c->geom.width, c->geom.height, 0);
-			}
+					c->geom.width, c->geom.height, 0);
 			if (c->mon == m)
 				setmon(c, newmon, c->tags);
 		}

--- a/dwl.c
+++ b/dwl.c
@@ -705,7 +705,7 @@ cleanupmon(struct wl_listener *listener, void *data)
 						c->geom.width, c->geom.height, 0);
 			}
 			if (c->mon == m)
-				setmon(c, newmon, 0);
+				setmon(c, newmon, c->tags);
 		}
 		break;
 	}

--- a/dwl.c
+++ b/dwl.c
@@ -695,7 +695,6 @@ cleanupmon(struct wl_listener *listener, void *data)
 	wl_list_remove(&m->link);
 	wlr_output_layout_remove(output_layout, m->wlr_output);
 
-	sgeom = *wlr_output_layout_get_box(output_layout, NULL);
 	updatemons();
 
 	wl_list_for_each(newmon, &mons, link) {
@@ -831,7 +830,6 @@ createmon(struct wl_listener *listener, void *data)
 	 * output (such as DPI, scale factor, manufacturer, etc).
 	 */
 	wlr_output_layout_add_auto(output_layout, wlr_output);
-	sgeom = *wlr_output_layout_get_box(output_layout, NULL);
 
 	for (size_t i = 0; i < nlayers; ++i)
 		wl_list_init(&m->layers[i]);
@@ -2151,6 +2149,7 @@ unmapnotify(struct wl_listener *listener, void *data)
 void
 updatemons()
 {
+	sgeom = *wlr_output_layout_get_box(output_layout, NULL);
 	Monitor *m;
 	wl_list_for_each(m, &mons, link) {
 		/* Get the effective monitor geometry to use for surfaces */

--- a/dwl.c
+++ b/dwl.c
@@ -195,6 +195,7 @@ static void applyexclusive(struct wlr_box *usable_area, uint32_t anchor,
 		int32_t margin_bottom, int32_t margin_left);
 static void applyrules(Client *c);
 static void arrange(Monitor *m);
+static void arrangefloat(Monitor *m, int sign);
 static void arrangelayer(Monitor *m, struct wl_list *list,
 		struct wlr_box *usable_area, bool exclusive);
 static void arrangelayers(Monitor *m);
@@ -470,6 +471,17 @@ arrange(Monitor *m)
 }
 
 void
+arrangefloat(Monitor *m, int sign)
+{
+	Client *c;
+	wl_list_for_each(c, &clients, link) {
+		if (c->isfloating)
+			resize(c, c->geom.x + m->w.width * sign, c->geom.y,
+					c->geom.width, c->geom.height, 0);
+	}
+}
+
+void
 arrangelayer(Monitor *m, struct wl_list *list, struct wlr_box *usable_area, bool exclusive)
 {
 	LayerSurface *layersurface;
@@ -693,6 +705,7 @@ cleanupmon(struct wl_listener *listener, void *data)
 	free(m);
 
 	updatemons();
+	arrangefloat(m, -1);
 }
 
 void
@@ -821,6 +834,11 @@ createmon(struct wl_listener *listener, void *data)
 
 	/* When adding monitors, the geometries of all monitors must be updated */
 	updatemons();
+	wl_list_for_each(m, &mons, link) {
+		/* the first monitor in the list is the most recently added */
+		arrangefloat(m, 1);
+		return;
+	}
 }
 
 void

--- a/dwl.c
+++ b/dwl.c
@@ -204,7 +204,7 @@ static void chvt(const Arg *arg);
 static void cleanup(void);
 static void cleanupkeyboard(struct wl_listener *listener, void *data);
 static void cleanupmon(struct wl_listener *listener, void *data);
-static void closemon(Monitor *m, Monitor *newmon);
+static void closemon(Monitor *m);
 static void commitlayersurfacenotify(struct wl_listener *listener, void *data);
 static void commitnotify(struct wl_listener *listener, void *data);
 static void createkeyboard(struct wlr_input_device *device);
@@ -688,7 +688,7 @@ void
 cleanupmon(struct wl_listener *listener, void *data)
 {
 	struct wlr_output *wlr_output = data;
-	Monitor *m = wlr_output->data, *newmon;
+	Monitor *m = wlr_output->data;
 
 	wl_list_remove(&m->destroy.link);
 	wl_list_remove(&m->frame.link);
@@ -696,24 +696,26 @@ cleanupmon(struct wl_listener *listener, void *data)
 	wlr_output_layout_remove(output_layout, m->wlr_output);
 
 	updatemons();
-	closemon(m, wl_container_of(mons.next, newmon, link));
+
+	selmon = wl_container_of(mons.next, selmon, link);
+	focusclient(selclient(), focustop(selmon), 1);
+	closemon(m);
+
 	free(m);
 }
 
 void
-closemon(Monitor *m, Monitor *newmon)
+closemon(Monitor *m)
 {
-	// move all the clients on a closed monitor to another one
+	// move closed monitor's clients to the focused one
 	Client *c;
 
-	selmon = newmon;
-	focusclient(selclient(), focustop(newmon), 1);
 	wl_list_for_each(c, &clients, link) {
 		if (c->isfloating && c->geom.x > m->m.width)
 			resize(c, c->geom.x - m->w.width, c->geom.y,
 				c->geom.width, c->geom.height, 0);
 		if (c->mon == m)
-			setmon(c, newmon, c->tags);
+			setmon(c, selmon, c->tags);
 	}
 }
 


### PR DESCRIPTION
Fixes the behavior of floating windows we talked about when changing the output configuration.

dwl used to crash when unplugging a monitor. This pullrequest handles this situation removing correctly the monitor, recalculating sgeom and moving all affected windows to the leftmost monitor.

These changes aren't strictly related to layer shell but we began to fix multi monitor here.